### PR TITLE
Make cryptopp include crosscompile compatible

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -Wall -std=c99
-AM_CPPFLAGS = -isystem /usr/include/$(CRYPTOLIB) $(LIBUSB_CFLAGS)
+AM_CPPFLAGS = -isystem $(SYSROOT)/usr/include/$(CRYPTOLIB) $(LIBUSB_CFLAGS)
 
 bin_PROGRAMS = tegrarcm
 tegrarcm_SOURCES = \


### PR DESCRIPTION
Allows user to set a SYSROOT variable for building against a specific root
filesystem.

Signed-off-by: Julian Scheel julian@jusst.de
